### PR TITLE
Allow getting ERC20 and SPL tokens metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,40 @@ import multichainWallet from 'multichain-crypto-wallet';
 
 The following methods are available with this SDK:
 
-- [Create Wallet](#create-wallet)
-- [Get Balance](#get-balance)
-- [Generate Wallet from Mnemonic](#generate-wallet-from-mnemonic)
-- [Get Address from Private Key](#get-address-from-private-key)
-- [Get Transaction Hash](#get-transaction-with-hash)
-- [Transfer](#transfer)
-- [Encrypt Private Key](#encrypt-private-key)
-- [Decrypt Encrypted JSON](#decrypt-encrypted-json)
-- [Get ERC20 Token Metadata](#get-erc20-token-metadata)
-- [Get SPL Token Metadata](#get-spl-token-metadata)
+- [Multichain Crypto Wallet](#multichain-crypto-wallet)
+  - [Installation](#installation)
+  - [Usage](#usage)
+    - [Javascript](#javascript)
+    - [TypeScript](#typescript)
+  - [Methods](#methods)
+    - [Create Wallet](#create-wallet)
+      - [Response](#response)
+    - [Get Balance](#get-balance)
+      - [Native coins](#native-coins)
+      - [Tokens](#tokens)
+      - [Response](#response-1)
+    - [Generate Wallet from Mnemonic](#generate-wallet-from-mnemonic)
+      - [Response](#response-2)
+    - [Get Address from Private Key](#get-address-from-private-key)
+      - [Response](#response-3)
+    - [Get Transaction](#get-transaction)
+      - [Response](#response-4)
+    - [Transfer](#transfer)
+      - [Ethereum Network](#ethereum-network)
+      - [Response](#response-5)
+    - [Encryptions](#encryptions)
+      - [Encrypt Private Key](#encrypt-private-key)
+      - [Response](#response-6)
+      - [Decrypt Encrypted JSON](#decrypt-encrypted-json)
+      - [Response](#response-7)
+    - [Token Info](#token-info)
+      - [Get ERC20 Token Info](#get-erc20-token-info)
+      - [Response](#response-8)
+      - [Solana Network](#solana-network)
+      - [Response](#response-9)
+    - [Token Info](#token-info-1)
+      - [Get SPL Token Info](#get-spl-token-info)
+      - [Response](#response-10)
 
 ### Create Wallet
 
@@ -343,16 +367,16 @@ const decrypted = await multichainWallet.getWalletFromEncryptedJson({
 
 ```
 
-### Token Metadata
+### Token Info
 
-#### Get ERC20 Token Metadata
+#### Get ERC20 Token Info
 
-Allows for fetching ERC20 tokens metadata from compatible blockchains by the token address
+Allows for fetching ERC20 tokens info from compatible blockchains by the token address
 
 ```javascript
-// getting token metadata.
+// getting token info.
 
-const metadata = await multichainWallet.getTokenMetadata({
+const info = await multichainWallet.getTokenInfo({
   address: '0x7fe03a082fd18a80a7dbd55e9b216bcf540557e4',
   network: 'ethereum',
   rpcUrl: 'https://rinkeby-light.eth.linkpool.io',
@@ -406,17 +430,17 @@ const transfer = await MultichainCryptoWallet.transfer({
 }
 ```
 
-### Token Metadata
+### Token Info
 
-#### Get SPL Token Metadata
+#### Get SPL Token Info
 
-Allows for fetching SPL tokens metadata on the solana by the token address.
+Allows for fetching SPL tokens info on the solana by the token address.
 Note: Token has to be available on the solana token list registry
 
 ```javascript
-// getting token metadata.
+// getting token info.
 
-const metadata = await multichainWallet.getTokenMetadata({
+const info = await multichainWallet.getTokenInfo({
   address: '7Xn4mM868daxsGVJmaGrYxg8CZiuqBnDwUse66s5ALmr',
   network: 'solana',
   rpcUrl: 'https://api.devnet.solana.com',

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ The following methods are available with this SDK:
 - [Transfer](#transfer)
 - [Encrypt Private Key](#encrypt-private-key)
 - [Decrypt Encrypted JSON](#decrypt-encrypted-json)
+- [Get ERC20 Token Metadata](#get-erc20-token-metadata)
+- [Get SPL Token Metadata](#get-spl-token-metadata)
 
 ### Create Wallet
 
@@ -341,6 +343,34 @@ const decrypted = await multichainWallet.getWalletFromEncryptedJson({
 
 ```
 
+### Token Metadata
+
+#### Get ERC20 Token Metadata
+
+Allows for fetching ERC20 tokens metadata from compatible blockchains by the token address
+
+```javascript
+// getting token metadata.
+
+const metadata = await multichainWallet.getTokenMetadata({
+  address: '0x7fe03a082fd18a80a7dbd55e9b216bcf540557e4',
+  network: 'ethereum',
+  rpcUrl: 'https://rinkeby-light.eth.linkpool.io',
+});
+```
+
+#### Response
+
+```javascript
+{
+  name: 'Mocked USDT',
+  symbol: 'USDT',
+  decimals: 6,
+  address: '0x7fe03a082fd18a80a7dbd55e9b216bcf540557e4',
+  totalSupply: 1000000000000
+}
+```
+
 #### Solana Network
 
 Allows for the transfer of SOL and tokens.
@@ -373,6 +403,37 @@ const transfer = await MultichainCryptoWallet.transfer({
 ```javascript
 {
   hash: '3nGq2yczqCpm8bF2dyvdPtXpnFLJ1oGWkDfD6neLbRay8SjNqYNhWQBKE1ZFunxvFhJ47FyT6igNpYPP293jXCZk';
+}
+```
+
+### Token Metadata
+
+#### Get SPL Token Metadata
+
+Allows for fetching SPL tokens metadata on the solana by the token address.
+Note: Token has to be available on the solana token list registry
+
+```javascript
+// getting token metadata.
+
+const metadata = await multichainWallet.getTokenMetadata({
+  address: '7Xn4mM868daxsGVJmaGrYxg8CZiuqBnDwUse66s5ALmr',
+  network: 'solana',
+  rpcUrl: 'https://api.devnet.solana.com',
+  cluster: 'devnet',
+});
+```
+
+#### Response
+
+```javascript
+{
+  name: 'SimpiansDEV',
+  symbol: 'SIMPDEV',
+  address: '7Xn4mM868daxsGVJmaGrYxg8CZiuqBnDwUse66s5ALmr',
+  decimals: 0,
+  logoUrl: 'https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/7Xn4mM868daxsGVJmaGrYxg8CZiuqBnDwUse66s5ALmr/logo.png',
+  totalSupply: 10000000
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ The following methods are available with this SDK:
     - [Transfer](#transfer)
       - [Ethereum Network](#ethereum-network)
       - [Response](#response-5)
+      - [Solana Network](#solana-network)
+      - [Response](#response-9)
     - [Encryptions](#encryptions)
       - [Encrypt Private Key](#encrypt-private-key)
       - [Response](#response-6)
@@ -68,9 +70,6 @@ The following methods are available with this SDK:
     - [Token Info](#token-info)
       - [Get ERC20 Token Info](#get-erc20-token-info)
       - [Response](#response-8)
-      - [Solana Network](#solana-network)
-      - [Response](#response-9)
-    - [Token Info](#token-info-1)
       - [Get SPL Token Info](#get-spl-token-info)
       - [Response](#response-10)
 

--- a/package.json
+++ b/package.json
@@ -69,9 +69,9 @@
   },
   "dependencies": {
     "@solana/spl-token": "^0.2.0",
-    "@solana/spl-token-registry": "^0.2.3817",
     "@solana/web3.js": "^1.39.1",
     "@truffle/hdwallet-provider": "^2.0.5",
+    "axios": "^0.27.2",
     "bip39": "^3.0.4",
     "bs58": "^5.0.0",
     "buffer-layout": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
   },
   "dependencies": {
     "@solana/spl-token": "^0.2.0",
+    "@solana/spl-token-registry": "^0.2.3817",
     "@solana/web3.js": "^1.39.1",
     "@truffle/hdwallet-provider": "^2.0.5",
     "bip39": "^3.0.4",

--- a/src/common/helpers/ethersHelper.ts
+++ b/src/common/helpers/ethersHelper.ts
@@ -8,6 +8,7 @@ import {
   GetTransactionPayload,
   GetWalletFromEncryptedjsonPayload,
   TransferPayload,
+  IGetTokenMetadataPayload,
 } from '../utils/types';
 import { successResponse } from '../utils';
 
@@ -208,6 +209,32 @@ const getWalletFromEncryptedJson = async (
   });
 };
 
+const getTokenMetadata = async ({
+  address,
+  rpcUrl,
+}: IGetTokenMetadataPayload) => {
+  const { contract } = await getContract({ tokenAddress: address, rpcUrl });
+
+  if (contract) {
+    const [name, symbol, decimals, totalSupply] = await Promise.all([
+      contract.name(),
+      contract.symbol(),
+      contract.decimals(),
+      contract.totalSupply(),
+    ]);
+
+    return successResponse({
+      name,
+      symbol,
+      decimals,
+      address: contract.address,
+      totalSupply: parseInt(ethers.utils.formatUnits(totalSupply, decimals)),
+    });
+  }
+
+  return;
+};
+
 export default {
   getBalance,
   createWallet,
@@ -217,4 +244,5 @@ export default {
   getTransaction,
   getEncryptedJsonFromPrivateKey,
   getWalletFromEncryptedJson,
+  getTokenMetadata,
 };

--- a/src/common/helpers/ethersHelper.ts
+++ b/src/common/helpers/ethersHelper.ts
@@ -9,6 +9,7 @@ import {
   GetWalletFromEncryptedjsonPayload,
   TransferPayload,
   IGetTokenMetadataPayload,
+  ITokenMetadata,
 } from '../utils/types';
 import { successResponse } from '../utils';
 
@@ -223,15 +224,15 @@ const getTokenMetadata = async ({
       contract.totalSupply(),
     ]);
 
-    return successResponse({
+    const data: ITokenMetadata = {
       name,
       symbol,
       decimals,
       address: contract.address,
       totalSupply: parseInt(ethers.utils.formatUnits(totalSupply, decimals)),
-    });
+    };
+    return successResponse({ ...data });
   }
-
   return;
 };
 

--- a/src/common/helpers/ethersHelper.ts
+++ b/src/common/helpers/ethersHelper.ts
@@ -8,8 +8,8 @@ import {
   GetTransactionPayload,
   GetWalletFromEncryptedjsonPayload,
   TransferPayload,
-  IGetTokenMetadataPayload,
-  ITokenMetadata,
+  IGetTokenInfoPayload,
+  ITokenInfo,
 } from '../utils/types';
 import { successResponse } from '../utils';
 
@@ -210,10 +210,7 @@ const getWalletFromEncryptedJson = async (
   });
 };
 
-const getTokenMetadata = async ({
-  address,
-  rpcUrl,
-}: IGetTokenMetadataPayload) => {
+const getTokenInfo = async ({ address, rpcUrl }: IGetTokenInfoPayload) => {
   const { contract } = await getContract({ tokenAddress: address, rpcUrl });
 
   if (contract) {
@@ -224,7 +221,7 @@ const getTokenMetadata = async ({
       contract.totalSupply(),
     ]);
 
-    const data: ITokenMetadata = {
+    const data: ITokenInfo = {
       name,
       symbol,
       decimals,
@@ -245,5 +242,5 @@ export default {
   getTransaction,
   getEncryptedJsonFromPrivateKey,
   getWalletFromEncryptedJson,
-  getTokenMetadata,
+  getTokenInfo,
 };

--- a/src/common/helpers/solanaHelper.ts
+++ b/src/common/helpers/solanaHelper.ts
@@ -9,9 +9,9 @@ import {
   BalancePayload,
   GetAddressFromPrivateKeyPayload,
   GetTransactionPayload,
-  IGetTokenMetadataPayload,
+  IGetTokenInfoPayload,
   ISplTokenInfo,
-  ITokenMetadata,
+  ITokenInfo,
   TransferPayload,
 } from '../utils/types';
 import * as bs58 from 'bs58';
@@ -219,14 +219,14 @@ const getTransaction = async (args: GetTransactionPayload) => {
   }
 };
 
-const getTokenMetadata = async (args: IGetTokenMetadataPayload) => {
+const getTokenInfo = async (args: IGetTokenInfoPayload) => {
   try {
     const connection = getConnection(args.rpcUrl);
     const tokenList = await getTokenList(args.cluster!);
     const token = tokenList.find(token => token.address === args.address);
 
     if (token) {
-      const data: ITokenMetadata = {
+      const data: ITokenInfo = {
         name: token.name,
         symbol: token.symbol,
         address: token.address,
@@ -272,5 +272,5 @@ export default {
   transfer,
   getAddressFromPrivateKey,
   getTransaction,
-  getTokenMetadata,
+  getTokenInfo,
 };

--- a/src/common/helpers/solanaHelper.ts
+++ b/src/common/helpers/solanaHelper.ts
@@ -258,7 +258,7 @@ const getTokenList = async (
 
   if (response.data && response.data.tokens) {
     return response.data.tokens.filter(
-      (data: any) => data.chainId === chainId[cluster]
+      (data: ISplTokenInfo) => data.chainId === chainId[cluster]
     );
   }
 

--- a/src/common/utils/types.ts
+++ b/src/common/utils/types.ts
@@ -53,3 +53,9 @@ export interface GetWalletFromEncryptedjsonPayload {
   password: string;
   network: string;
 }
+
+export interface IGetTokenMetadataPayload {
+  network: string;
+  rpcUrl: string;
+  address: string;
+}

--- a/src/common/utils/types.ts
+++ b/src/common/utils/types.ts
@@ -58,4 +58,14 @@ export interface IGetTokenMetadataPayload {
   network: string;
   rpcUrl: string;
   address: string;
+  cluster?: string;
+}
+
+export interface ITokenMetadata {
+  name: string;
+  symbol: string;
+  address: string;
+  decimals: number;
+  totalSupply: number;
+  logoUrl?: string;
 }

--- a/src/common/utils/types.ts
+++ b/src/common/utils/types.ts
@@ -54,14 +54,14 @@ export interface GetWalletFromEncryptedjsonPayload {
   network: string;
 }
 
-export interface IGetTokenMetadataPayload {
+export interface IGetTokenInfoPayload {
   network: string;
   rpcUrl: string;
   address: string;
   cluster?: 'mainnet-beta' | 'testnet' | 'devnet';
 }
 
-export interface ITokenMetadata {
+export interface ITokenInfo {
   name: string;
   symbol: string;
   address: string;

--- a/src/common/utils/types.ts
+++ b/src/common/utils/types.ts
@@ -58,7 +58,7 @@ export interface IGetTokenMetadataPayload {
   network: string;
   rpcUrl: string;
   address: string;
-  cluster?: string;
+  cluster?: 'mainnet-beta' | 'testnet' | 'devnet';
 }
 
 export interface ITokenMetadata {
@@ -68,4 +68,15 @@ export interface ITokenMetadata {
   decimals: number;
   totalSupply: number;
   logoUrl?: string;
+}
+
+export interface ISplTokenInfo {
+  chainId: number;
+  address: string;
+  symbol: string;
+  name: string;
+  decimals: number;
+  logoURI?: string;
+  tags: string[];
+  extensions: any;
 }

--- a/src/services/wallet/index.ts
+++ b/src/services/wallet/index.ts
@@ -10,6 +10,7 @@ import {
   GetTransactionPayload,
   GetWalletFromEncryptedjsonPayload,
   GetEncryptedJsonFromPrivateKey,
+  IGetTokenMetadataPayload,
 } from '../../common/utils/types';
 
 export async function getBalance(args: BalancePayload) {
@@ -128,6 +129,17 @@ export async function getWalletFromEncryptedJson(
       return await ethereumHelper.getWalletFromEncryptedJson({ ...args });
     }
 
+    return;
+  } catch (error) {
+    throw error;
+  }
+}
+
+export async function getTokenMetadata(args: IGetTokenMetadataPayload) {
+  try {
+    if (args.network === 'ethereum') {
+      return await ethereumHelper.getTokenMetadata({ ...args });
+    }
     return;
   } catch (error) {
     throw error;

--- a/src/services/wallet/index.ts
+++ b/src/services/wallet/index.ts
@@ -139,6 +139,8 @@ export async function getTokenMetadata(args: IGetTokenMetadataPayload) {
   try {
     if (args.network === 'ethereum') {
       return await ethereumHelper.getTokenMetadata({ ...args });
+    } else if (args.network === 'solana') {
+      return solanaHelper.getTokenMetadata({ ...args });
     }
     return;
   } catch (error) {

--- a/src/services/wallet/index.ts
+++ b/src/services/wallet/index.ts
@@ -10,7 +10,7 @@ import {
   GetTransactionPayload,
   GetWalletFromEncryptedjsonPayload,
   GetEncryptedJsonFromPrivateKey,
-  IGetTokenMetadataPayload,
+  IGetTokenInfoPayload,
 } from '../../common/utils/types';
 
 export async function getBalance(args: BalancePayload) {
@@ -135,12 +135,12 @@ export async function getWalletFromEncryptedJson(
   }
 }
 
-export async function getTokenMetadata(args: IGetTokenMetadataPayload) {
+export async function getTokenInfo(args: IGetTokenInfoPayload) {
   try {
     if (args.network === 'ethereum') {
-      return await ethereumHelper.getTokenMetadata({ ...args });
+      return await ethereumHelper.getTokenInfo({ ...args });
     } else if (args.network === 'solana') {
-      return solanaHelper.getTokenMetadata({ ...args });
+      return solanaHelper.getTokenInfo({ ...args });
     }
     return;
   } catch (error) {

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -233,4 +233,20 @@ describe('MultichainCryptoWallet', () => {
     expect(typeof (data && data.decimals)).toBe('number');
     expect(typeof (data && data.totalSupply)).toBe('number');
   });
+
+  it('get SPL token metadata', async () => {
+    const data = await getTokenMetadata({
+      address: '7Xn4mM868daxsGVJmaGrYxg8CZiuqBnDwUse66s5ALmr',
+      network: 'solana',
+      rpcUrl: 'https://api.devnet.solana.com',
+      cluster: 'devnet',
+    });
+
+    expect(typeof data).toBe('object');
+    expect(typeof (data && data.name)).toBe('string');
+    expect(typeof (data && data.symbol)).toBe('string');
+    expect(typeof (data && data.address)).toBe('string');
+    expect(typeof (data && data.decimals)).toBe('number');
+    expect(typeof (data && data.totalSupply)).toBe('number');
+  });
 });

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -7,6 +7,7 @@ import {
   transfer,
   getWalletFromEncryptedJson,
   getEncryptedJsonFromPrivateKey,
+  getTokenMetadata,
 } from '../src';
 
 describe('MultichainCryptoWallet', () => {
@@ -216,5 +217,20 @@ describe('MultichainCryptoWallet', () => {
     expect(typeof data).toBe('object');
     expect(typeof (data && data.privateKey)).toBe('string');
     expect(typeof (data && data.address)).toBe('string');
+  });
+
+  it('get ERC20 token metadata', async () => {
+    const data = await getTokenMetadata({
+      address: '0x7fe03a082fd18a80a7dbd55e9b216bcf540557e4',
+      network: 'ethereum',
+      rpcUrl: 'https://rinkeby-light.eth.linkpool.io',
+    });
+
+    expect(typeof data).toBe('object');
+    expect(typeof (data && data.name)).toBe('string');
+    expect(typeof (data && data.symbol)).toBe('string');
+    expect(typeof (data && data.address)).toBe('string');
+    expect(typeof (data && data.decimals)).toBe('number');
+    expect(typeof (data && data.totalSupply)).toBe('number');
   });
 });

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -7,7 +7,7 @@ import {
   transfer,
   getWalletFromEncryptedJson,
   getEncryptedJsonFromPrivateKey,
-  getTokenMetadata,
+  getTokenInfo,
 } from '../src';
 
 describe('MultichainCryptoWallet', () => {
@@ -219,8 +219,8 @@ describe('MultichainCryptoWallet', () => {
     expect(typeof (data && data.address)).toBe('string');
   });
 
-  it('get ERC20 token metadata', async () => {
-    const data = await getTokenMetadata({
+  it('get ERC20 token info', async () => {
+    const data = await getTokenInfo({
       address: '0x7fe03a082fd18a80a7dbd55e9b216bcf540557e4',
       network: 'ethereum',
       rpcUrl: 'https://rinkeby-light.eth.linkpool.io',
@@ -234,8 +234,8 @@ describe('MultichainCryptoWallet', () => {
     expect(typeof (data && data.totalSupply)).toBe('number');
   });
 
-  it('get SPL token metadata', async () => {
-    const data = await getTokenMetadata({
+  it('get SPL token info', async () => {
+    const data = await getTokenInfo({
       address: '7Xn4mM868daxsGVJmaGrYxg8CZiuqBnDwUse66s5ALmr',
       network: 'solana',
       rpcUrl: 'https://api.devnet.solana.com',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1665,13 +1665,6 @@
   dependencies:
     buffer "~6.0.3"
 
-"@solana/spl-token-registry@^0.2.3817":
-  version "0.2.3817"
-  resolved "https://registry.yarnpkg.com/@solana/spl-token-registry/-/spl-token-registry-0.2.3817.tgz#c2547680b543f0087b0e26ec01bacc4999fdbbc7"
-  integrity sha512-L2FAvfkdkt85uEKho8voaEK5aJxKPrjVysHccA0IraP8O/Tqzl9avJlAqWozPrAChZJfsP4/EzskWl8U3WWqBg==
-  dependencies:
-    cross-fetch "3.0.6"
-
 "@solana/spl-token@^0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@solana/spl-token/-/spl-token-0.2.0.tgz#329bb6babb5de0f9c40035ddb1657f01a8347acd"
@@ -2282,6 +2275,14 @@ axios@^0.21.1:
   integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
   dependencies:
     follow-redirects "^1.14.0"
+
+axios@^0.27.2:
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
+  integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
+  dependencies:
+    follow-redirects "^1.14.9"
+    form-data "^4.0.0"
 
 axobject-query@^2.2.0:
   version "2.2.0"
@@ -2944,7 +2945,7 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-combined-stream@^1.0.6, combined-stream@~1.0.6:
+combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -3049,13 +3050,6 @@ create-hmac@1.1.7, create-hmac@^1.1.4, create-hmac@^1.1.7:
     ripemd160 "^2.0.0"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
-
-cross-fetch@3.0.6:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.6.tgz#3a4040bc8941e653e0e9cf17f29ebcd177d3365c"
-  integrity sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==
-  dependencies:
-    node-fetch "2.6.1"
 
 cross-fetch@^2.1.0:
   version "2.2.6"
@@ -4403,6 +4397,11 @@ follow-redirects@^1.14.0:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
   integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
 
+follow-redirects@^1.14.9:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.0.tgz#06441868281c86d0dda4ad8bdaead2d02dca89d4"
+  integrity sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==
+
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -4412,6 +4411,15 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 form-data@~2.3.2:
   version "2.3.3"
@@ -6304,11 +6312,6 @@ node-addon-api@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-2.0.2.tgz#432cfa82962ce494b132e9d72a15b29f71ff5d32"
   integrity sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==
-
-node-fetch@2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
-  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-fetch@2.6.7, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.6.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1665,6 +1665,13 @@
   dependencies:
     buffer "~6.0.3"
 
+"@solana/spl-token-registry@^0.2.3817":
+  version "0.2.3817"
+  resolved "https://registry.yarnpkg.com/@solana/spl-token-registry/-/spl-token-registry-0.2.3817.tgz#c2547680b543f0087b0e26ec01bacc4999fdbbc7"
+  integrity sha512-L2FAvfkdkt85uEKho8voaEK5aJxKPrjVysHccA0IraP8O/Tqzl9avJlAqWozPrAChZJfsP4/EzskWl8U3WWqBg==
+  dependencies:
+    cross-fetch "3.0.6"
+
 "@solana/spl-token@^0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@solana/spl-token/-/spl-token-0.2.0.tgz#329bb6babb5de0f9c40035ddb1657f01a8347acd"
@@ -3042,6 +3049,13 @@ create-hmac@1.1.7, create-hmac@^1.1.4, create-hmac@^1.1.7:
     ripemd160 "^2.0.0"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+cross-fetch@3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.6.tgz#3a4040bc8941e653e0e9cf17f29ebcd177d3365c"
+  integrity sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==
+  dependencies:
+    node-fetch "2.6.1"
 
 cross-fetch@^2.1.0:
   version "2.2.6"
@@ -6290,6 +6304,11 @@ node-addon-api@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-2.0.2.tgz#432cfa82962ce494b132e9d72a15b29f71ff5d32"
   integrity sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==
+
+node-fetch@2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-fetch@2.6.7, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.6.7"


### PR DESCRIPTION
I added the ability to get the metadata for ERC20 and SPL tokens.

- ERC20 tokens metadata are fetched by their address by invoking the following methods of a standard ERC20 smart contract ["name", "symbol", "totalSupply"] and lastly the token address.

- SPL tokens metadata are fetched from the solana token list registry, so the SPL token address that it's metadata is being fetched has to be available to the registry. The total supply is being gotten directly from the network with the solana/web3.js library.

- Logo URL is only available for SPL token metadat since the registry provide that, but currently unavailable for ERC20 tokens and will work on getting them available for ERC20 tokens as I find more information about it.
