### PR TITLE
Removes 0x prefix from gen tron-pk in `generateWalletFromMnemonic`

### DIFF
--- a/src/common/helpers/tronHelper.ts
+++ b/src/common/helpers/tronHelper.ts
@@ -81,9 +81,13 @@ const generateWalletFromMnemonic = (
   const path = derivationPath || "m/44'/195'/0'/0/0";
   const account = TronWeb.fromMnemonic(mnemonic, path);
 
+  const privateKey = account.privateKey.startsWith('0x')
+    ? account.privateKey.substring(2)
+    : account.privateKey;
+
   return successResponse({
     address: account.address,
-    privateKey: account.privateKey,
+    privateKey: privateKey,
     mnemonic: mnemonic,
   });
 };


### PR DESCRIPTION
## Description

Removes `0x` prefix from gen tron-pk in `generateWalletFromMnemonic`

Fixes: #37


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran `npm run test` and my test cases cover all the lines and branches of the added code.
- [x] I ran `npm run build` with success.
- [x] I have tested my code on the live network.
- [x] I have checked the Deploy Preview and it looks correct.