### PR TITLE
fix param order for bitcoin wallets gen

### DIFF
--- a/src/services/wallet/index.ts
+++ b/src/services/wallet/index.ts
@@ -110,10 +110,18 @@ function generateWalletFromMnemonic(args: GenerateWalletFromMnemonicPayload) {
       throw new Error('Invalid network');
     }
 
-    return helper.generateWalletFromMnemonic(
-      args.mnemonic,
-      args.derivationPath
-    );
+    if (args.network.startsWith('bitcoin')) {
+      return helper.generateWalletFromMnemonic(
+        args.network,
+        args.mnemonic,
+        args.derivationPath
+      );
+    } else {
+      return helper.generateWalletFromMnemonic(
+        args.mnemonic,
+        args.derivationPath
+      );
+    }
   } catch (error) {
     throw error;
   }


### PR DESCRIPTION
## Description

Issue in #36 happened because bitcoin expected params as `network`, `mnemonic` & `derivationPath` but we passed `mnemonic` & `derivationPath`, so all bitcoin wallets had the same address

Fixes #36

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran `npm run test` and my test cases cover all the lines and branches of the added code.
- [x] I ran `npm run build` with success.
- [x] I have tested my code on the live network.
- [x] I have checked the Deploy Preview and it looks correct.